### PR TITLE
Upgrade to net 8

### DIFF
--- a/NibrsModels.csproj
+++ b/NibrsModels.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
       <PackageReference Include="MongoDB.Bson">
-        <Version>3.3.0</Version>
+        <Version>3.4.0</Version>
       </PackageReference>
       <PackageReference Include="Newtonsoft.Json">
         <Version>13.0.3</Version>

--- a/NibrsModels.csproj
+++ b/NibrsModels.csproj
@@ -1,26 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <RepositoryUrl>https://github.com/teisdbr/NibrsModels.git</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageTags>Incident, DataModels</PackageTags>
         <Description>Technology Engineers' own C# utility library with the Reportable Incident Data Models</Description>
-        <Version>1.3.3</Version>
+        <Version>1.3.14</Version>
         <Authors>Technology Engineers</Authors>
         <Copyright>Copyright 2020</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>1.3.6</PackageVersion>
+        <PackageVersion>1.3.14</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="MongoDB.Bson">
-        <Version>2.10.2</Version>
+        <Version>3.3.0</Version>
       </PackageReference>
       <PackageReference Include="Newtonsoft.Json">
-        <Version>12.0.3</Version>
+        <Version>13.0.3</Version>
       </PackageReference>
       <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-      <PackageReference Include="Util" Version="1.0.7" />
+      <PackageReference Include="Util" Version="1.0.34" />
     </ItemGroup>
 </Project>

--- a/NibrsModels.sln
+++ b/NibrsModels.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NibrsModels", "NibrsModels.csproj", "{4598A7ED-9132-1A11-109E-E56536E6B6EC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4598A7ED-9132-1A11-109E-E56536E6B6EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4598A7ED-9132-1A11-109E-E56536E6B6EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4598A7ED-9132-1A11-109E-E56536E6B6EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4598A7ED-9132-1A11-109E-E56536E6B6EC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EECC33A8-0626-49E7-B074-3182C90C1EE5}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
# Changes:
- Upgraded project to .NET 8.
- Upgraded Util to 1.0.34.
- Upgraded other packages to latest supported version.

# Notes:
- LibrsDataModels uses NibrsModels as a NuGet package, and so that will be next.